### PR TITLE
add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,41 @@
+import os
+import sys
+
+
+from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand
+
+here = os.path.abspath(os.path.dirname(__file__))
+README = open(os.path.join(here, 'README.md')).read()
+
+
+
+requires = [
+    'paramiko',
+    'protobuf'
+]
+
+test_requires = [
+]
+
+
+setup(name='pyrs',
+      version='0.1',
+      description='Using this library you can control your retroshare instance programatically in python.',
+      long_description=README,
+      classifiers=[
+      "Programming Language :: Python",
+          "Topic :: Communications :: Chat",
+          "Topic :: Communications :: File Sharing",
+      ],
+      author='drbob',
+      author_email='',
+      url='https://github.com/drbob/pyrs',
+      keywords='retroshare protobuf rpc',
+      packages=find_packages(),
+      include_package_data=True,
+      zip_safe=False,
+      install_requires=requires,
+      #extras_require=extras_require,
+      tests_require=test_requires,
+      )


### PR DESCRIPTION
I added a basic setup.py. Now python setup.py build and setup.py install will work as expected and allow 'import pyrs' install-wide.

(Tested on fedora 17 -- should work on most if not all 2.6+ installations. 3.x untested)

I you'd like to bother to add me:

Af8AAAJkxsBNBFIDaCgBCAC3D7Y+saRq2nypA+b9Qy10IIDqJ6qCn9nF17TjflNX
FtHHZ4jmzZIh2xl3lIgH9wa0aKAT3rXrw3roT9FjVhio6vrLrE4U93xREs13aA7U
zPQEKQs6nb9M9JSORzDTFXD5xrJnK2KbZ+ISPOd1gt9WGk52ZGZVWiOPb2g73Iwr
eR7mzoMAPLSzhjW7U9/ENH9k/8aLh5QP+9BUuBs1vz5ls0yJq+Qim251M3sE5d87
TtvjJvZiVa6JUACwkPDzlz7M5xC8SqKyVNXHrYs7R/pAtMEjaanIUwgjIAPCaN5e
gyLfySEiwZXAZ03HOW2HEG+LnSSc8l6mEdSZuVzktV2/ABEBAAHNMGlnb3IgKEdl
bmVyYXRlZCBieSBSZXRyb1NoYXJlKSA8aWdvckBjLWJhc2Uub3JnPsLAXwQTAQIA
EwUCUgNoKAkQtNO36Vd3+oUCGQEAAN2JB/96Ld0pRoZRvGcmMzalnLcts7dHhpsb
96NnWE12I89Q6605Hvd8Pq7KrMTw4V16Xqvf6mcVIU2fdcMrCknPf1kt6/Cnvir7
QfLnZYEvSbp6LFn9Cu4LuTN5TVEHSewDFXQfkMH5zyK7DT1Jlc6t1KEBaODcTqar
TkYlNTlEknlCSIz2mxWhyCYseahfxTSgad2ZfHPUR9mvFUiwVJjpLZHsnlO+fytY
XpJE8NSLazCqXQ6TA6PL1cBuXpx06QZnb6fYuKT4vdD//VTKcg9x8deok3BebgTt
f//YnfMg5c7VWSJNH0kDoQgEkDPA9Cxh4FZ+vTSrwiMOgxgtN52bXq/IAgZbZgli
IC4DBgoAAJggLgQABgZsYXB0b3AFEGfs7Y2EsHC779hXNfKOBBM=
